### PR TITLE
Curl should follow redirects

### DIFF
--- a/linkcheck
+++ b/linkcheck
@@ -47,6 +47,11 @@ RETRIES=3
 ###
 STATUS_CODES=200
 
+###
+### Whether or not we should follow redirects
+###
+FOLLOW_REDIRECTS=false
+
 
 ############################################################
 # Fixed global variables
@@ -68,7 +73,7 @@ MY_VERSION="v0.6"
 ### Usage
 ###
 print_usage() {
-	echo "Usage: linkcheck [-e -i -t -r -c] [<path>]"
+	echo "Usage: linkcheck [-e -i -t -r -c -l] [<path>]"
 	echo "       linkcheck --version"
 	echo "       linkcheck --help"
 	echo
@@ -107,6 +112,8 @@ print_usage() {
 	echo "            -c '200,301'"
 	echo "            -c '200,301,302'"
 	echo
+	echo "-l        Specify whether to follow redirect URLs or not."
+	echo "          This argument does not accept parameters."
 	echo
 	echo "--version Show version and exit."
 	echo "--help    Show this help screen."
@@ -211,6 +218,11 @@ probe_urls() {
 
 		printf "\\e[0;33m[TEST]\\e[0m %s ..." "${url}"
 
+		# If we follow redirects, we get the latest address first and then check it
+		if [ ${FOLLOW_REDIRECTS} = true ]; then
+			url="$(curl -Ls -o /dev/null -w %{url_effective} ${url})"
+		fi
+
 		# Get header from URL
 		eval "$( curl -SsI \
 			--retry-delay 2 \
@@ -248,7 +260,7 @@ probe_urls() {
 ############################################################
 # Entrypoint: arguments
 ############################################################
-#-e -i -t -r -c
+#-e -i -t -r -c -l
 while [ $# -gt 0  ]; do
 	case "${1}" in
 
@@ -305,7 +317,11 @@ while [ $# -gt 0  ]; do
 				exit 1
 			fi
 			;;
-
+		# ----------------------------------------
+		-l)
+			shift
+			FOLLOW_REDIRECTS=true
+			;;
 		# ----------------------------------------
 		--help)
 			print_usage


### PR DESCRIPTION
Hey there,

how do you solve redirects? I noticed that the script does not follow redirects, which may be a problem in case the redirected page is dead. With this change, you'll see something like:

```
[OK]   http://hibernate.sourceforge.net/hibernate-mapping-3.0.dtd HTTP/1.1 301 Moved Permanently
HTTP/1.0 301 Moved Permanently
HTTP/1.1 200 OK
```

Or:

```
[ERR]  http://maven.org HTTP/1.1 302 Moved Temporarily
HTTP/1.1 404 Not Found
```

What do you think? 

Also, I noticed that the curl does not follow insecure links, i.e. links with self-signed certificate etc. We may do two things here:

1. follow my change with `--insecure`, so that those links are checked as well
2. Mark all insecure links as fail, in which case, I should change my patch to `--location-trusted`

Up to you.